### PR TITLE
Solve the Leaked IntentReceiver for the bluetooth sensor

### DIFF
--- a/src/com/ubhave/sensormanager/sensors/pull/BluetoothSensor.java
+++ b/src/com/ubhave/sensormanager/sensors/pull/BluetoothSensor.java
@@ -134,13 +134,6 @@ public class BluetoothSensor extends AbstractPullSensor
 				}
 			}
 		};
-
-		// Register the BroadcastReceiver: note that this does NOT start a scan
-		// or anything
-		IntentFilter found = new IntentFilter(BluetoothDevice.ACTION_FOUND);
-		IntentFilter finished = new IntentFilter(BluetoothAdapter.ACTION_DISCOVERY_FINISHED);
-		applicationContext.registerReceiver(receiver, found);
-		applicationContext.registerReceiver(receiver, finished);
 	}
 
 	protected String getLogTag()
@@ -185,7 +178,15 @@ public class BluetoothSensor extends AbstractPullSensor
 		}
 		cyclesRemaining = (Integer) sensorConfig.getParameter(PullSensorConfig.NUMBER_OF_SENSE_CYCLES);
 		bluetooth.startDiscovery();
-		return true;
+
+        // Register the BroadcastReceiver: note that this does NOT start a scan
+        // or anything
+        IntentFilter found = new IntentFilter(BluetoothDevice.ACTION_FOUND);
+        IntentFilter finished = new IntentFilter(BluetoothAdapter.ACTION_DISCOVERY_FINISHED);
+        applicationContext.registerReceiver(receiver, found);
+        applicationContext.registerReceiver(receiver, finished);
+
+        return true;
 	}
 
 	// Called when a scan is finished


### PR DESCRIPTION
When you don't start sensing the bluetooth sensor, it is created, registering the broadcast receiver, but it is not unregistered causing a Leaked IntentReceiver.

The registerReceiver was moved to the startSensing because we don't need to receive broadcast if we are not sensing the bluetooth, and the unregister it is at stopSensing.
